### PR TITLE
chore(ci): add cargo-udeps scan to PR CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -129,3 +129,22 @@ jobs:
           cat $HOME/.safe/authd/logs/sn_authd.out
           cat $HOME/.safe/authd/logs/sn_authd.err
         if: failure()
+
+  cargo-udeps:
+    name: Unused dependency check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      # Install Rust and required components
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly
+          override: true
+
+      # Install and run cargo udeps to find unused cargo dependencies
+      - name: cargo-udeps duplicate dependency check
+        run: |
+          cargo install cargo-udeps --locked
+          cd native
+          cargo +nightly udeps --all-targets


### PR DESCRIPTION
Note that the 3 CI `Test` stages will fail until new CLI, authd and node versions are released to bring them in line with recent changes. Have marked these as not required CI stages until that point.