### PR TITLE
chore(ci): download sn_authd from s3 for use in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,6 +11,7 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   SN_CLI_VERSION: "0.15.0"
   SN_NODE_VERSION: "0.25.1"
+  SN_AUTHD_VERSION: "0.0.11"
 
 jobs:
   tests:
@@ -33,17 +34,17 @@ jobs:
 
       - name: Download Safe Node Ubuntu
         if: matrix.os == 'ubuntu-latest'
-        run:  wget "https://github.com/maidsafe/sn_node/releases/download/${{env.SN_NODE_VERSION}}/sn_node-${{env.SN_NODE_VERSION}}-x86_64-unknown-linux-musl.tar.gz" -O ./node.tar.gz;
+        run:  wget "https://github.com/maidsafe/sn_node/releases/download/v${{env.SN_NODE_VERSION}}/sn_node-${{env.SN_NODE_VERSION}}-x86_64-unknown-linux-musl.tar.gz" -O ./node.tar.gz;
 
       - name: Download Safe Node Mac
         if: matrix.os == 'macos-latest'
-        run: wget "https://github.com/maidsafe/sn_node/releases/download/${{env.SN_NODE_VERSION}}/sn_node-${{env.SN_NODE_VERSION}}-x86_64-apple-darwin.tar.gz" -O ./node.tar.gz;
+        run: wget "https://github.com/maidsafe/sn_node/releases/download/v${{env.SN_NODE_VERSION}}/sn_node-${{env.SN_NODE_VERSION}}-x86_64-apple-darwin.tar.gz" -O ./node.tar.gz;
 
       - name: Download Safe Node Win
         if: matrix.os == 'windows-latest'
         run: |
           choco install wget
-          wget "https://github.com/maidsafe/sn_node/releases/download/${{env.SN_NODE_VERSION}}/sn_node-${{env.SN_NODE_VERSION}}-x86_64-pc-windows-msvc.tar.gz" -O ./node.tar.gz;
+          wget "https://github.com/maidsafe/sn_node/releases/download/v${{env.SN_NODE_VERSION}}/sn_node-${{env.SN_NODE_VERSION}}-x86_64-pc-windows-msvc.tar.gz" -O ./node.tar.gz;
 
       - name: Place Safe Node
         run:  |
@@ -54,30 +55,42 @@ jobs:
 
       - name: Download Safe CLI Linux
         if: matrix.os == 'ubuntu-latest'
-        run: wget "https://github.com/maidsafe/sn_api/releases/download/${{env.SN_CLI_VERSION}}/sn_cli-${{env.SN_CLI_VERSION}}-x86_64-unknown-linux-gnu.tar.gz" -O ./safe.tar.gz;
+        run: wget "https://github.com/maidsafe/sn_api/releases/download/v${{env.SN_CLI_VERSION}}/sn_cli-${{env.SN_CLI_VERSION}}-x86_64-unknown-linux-gnu.tar.gz" -O ./safe.tar.gz;
 
       - name: Download Safe CLI Mac
         if: matrix.os == 'macos-latest'
-        run: wget "https://github.com/maidsafe/sn_api/releases/download/${{env.SN_CLI_VERSION}}/sn_cli-${{env.SN_CLI_VERSION}}-x86_64-apple-darwin.tar.gz" -O ./safe.tar.gz;
+        run: wget "https://github.com/maidsafe/sn_api/releases/download/v${{env.SN_CLI_VERSION}}/sn_cli-${{env.SN_CLI_VERSION}}-x86_64-apple-darwin.tar.gz" -O ./safe.tar.gz;
 
       - name: Download Safe CLI Windows
         if: matrix.os == 'windows-latest'
-        run: wget "https://github.com/maidsafe/sn_api/releases/download/${{env.SN_CLI_VERSION}}/sn_cli-${{env.SN_CLI_VERSION}}-x86_64-pc-windows-msvc.tar.gz" -O ./safe.tar.gz;
+        run: wget "https://github.com/maidsafe/sn_api/releases/download/v${{env.SN_CLI_VERSION}}/sn_cli-${{env.SN_CLI_VERSION}}-x86_64-pc-windows-msvc.tar.gz" -O ./safe.tar.gz;
 
       - name: Place Safe CLI
         run:  |
           ls .
           mkdir -p $HOME/.safe/sn_cli
-          mkdir -p $HOME/.safe/authd
           tar -xvzf ./safe.tar.gz -C $HOME/.safe/sn_cli/
           echo "::add-path::$HOME/.safe/sn_cli"
-          echo "::add-path::$HOME/.safe/authd"
           chmod +x $HOME/.safe/sn_cli/safe
 
+      - name: Download Safe authd Linux
+        if: matrix.os == 'ubuntu-latest'
+        run: wget "https://sn-api.s3.eu-west-2.amazonaws.com/sn_authd-${{env.SN_AUTHD_VERSION}}-x86_64-unknown-linux-musl.tar.gz" -O ./authd.tar.gz;
 
-      - name: Install Safe AuthD
-        run: |
-          safe auth install
+      - name: Download Safe authd Mac
+        if: matrix.os == 'macos-latest'
+        run: wget "https://sn-api.s3.eu-west-2.amazonaws.com/sn_authd-${{env.SN_AUTHD_VERSION}}-x86_64-apple-darwin.tar.gz" -O ./authd.tar.gz;
+
+      - name: Download Safe authd Windows
+        if: matrix.os == 'windows-latest'
+        run: wget "https://sn-api.s3.eu-west-2.amazonaws.com/sn_authd-${{env.SN_AUTHD_VERSION}}-x86_64-pc-windows-msvc.tar.gz" -O ./authd.tar.gz;
+
+      - name: Place Safe authd
+        run:  |
+          ls .
+          mkdir -p $HOME/.safe/authd
+          tar -xvzf ./authd.tar.gz -C $HOME/.safe/authd/
+          echo "::add-path::$HOME/.safe/authd"
           chmod +x $HOME/.safe/authd/sn_authd
 
       - name: Check Safe Versions


### PR DESCRIPTION
Currently CI installs authd via the CLI but sn_nodejs CI will fail
since the recent renaming tasks mean we expect a file of a
different name, and in a different dir.
Also makes sense to be able to configure the authd version, which
we get with this change.

Note that CI tests will fail until a new compatible version of the cli, authd & vault are released.